### PR TITLE
[database,dag] Add deviation calculation for BBQs in Uppsala

### DIFF
--- a/dags/deviations_uppsala_kommun.py
+++ b/dags/deviations_uppsala_kommun.py
@@ -1,0 +1,31 @@
+from datetime import timedelta, datetime
+
+from airflow import DAG, Dataset
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+for view_name, dataset_name in [
+    ("grillplatser_uppsala", "grillplatser"),
+]:
+    with DAG(
+        f"deviations-{view_name}",
+        description=f"Updates deviations based on v_deviations_{view_name}",
+        schedule=[Dataset(f"psql://upstream/uppsalakommun/{dataset_name}")],
+        start_date=datetime(2024, 2, 24, 0, 0),
+        catchup=False,
+        max_active_runs=1,
+        default_args=dict(
+            depends_on_past=False,
+            email=["jan@dalheimer.de"],
+            email_on_failure=True,
+            email_on_retry=False,
+            retries=1,
+            retry_delay=timedelta(minutes=5),
+        ),
+        tags=["provider:Uppsala kommun", "type:Deviations"],
+    ):
+        SQLExecuteQueryOperator(
+            task_id="deviations",
+            conn_id="PG_OSM",
+            sql=f"SELECT upstream.sync_deviations('{view_name}')",
+            outlets=[Dataset("psql://api/deviations")],
+        )

--- a/database/migrations/07b-upstream-datasets.sql
+++ b/database/migrations/07b-upstream-datasets.sql
@@ -94,7 +94,7 @@ VALUES (4, 'Badplatser och badanläggningar', 1, 'https://www.gavle.se/kommunens
        (463, 'Badplatser', 7, 'https://opendata.uppsala.se/datasets/aadc5420e8884d32b2efe0d10fbfdfe5_70/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Badplatser', NULL),
        (464, 'Friluftsområden och naturreservat', 7, 'https://opendata.uppsala.se/datasets/7f4010a678244813829db66246dfadbe_55/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Friluftsområden och naturreservat', NULL),
        (465, 'Fågeltorn och utkiksplatser', 7, 'https://opendata.uppsala.se/datasets/8df41ee8e7b9438ebe47d7ca34148463_69/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Fågeltorn och utkiksplatser', NULL),
-       (466, 'Grillplatser', 7, 'https://opendata.uppsala.se/datasets/635e669c84724263b090259ab6ad0572_68/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Grillplatser', NULL),
+       (466, 'Grillplatser', 7, 'https://opendata.uppsala.se/datasets/635e669c84724263b090259ab6ad0572_68/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Grillplatser', 'grillplatser_uppsala'),
        (467, 'Lekplatser', 7, 'https://opendata.uppsala.se/datasets/67c02b41524b45ad9d70c86fdd12131f_66/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Lekplatser', NULL),
        (468, 'Linnéstigar', 7, 'https://opendata.uppsala.se/datasets/67535a1e0dbe441ba251114e1b013779_65/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Linnéstigar', NULL),
        (469, 'Motionsspår', 7, 'https://opendata.uppsala.se/datasets/e037a040c42a403c9eb7b56ad881660c_86/about', 'https://creativecommons.org/publicdomain/zero/1.0/', NULL, 'Motionsspår', NULL),

--- a/database/migrations/37-v_deviation_grillplatser_uppsala.sql
+++ b/database/migrations/37-v_deviation_grillplatser_uppsala.sql
@@ -1,0 +1,90 @@
+CREATE OR REPLACE VIEW upstream.v_match_grillplatser_uppsala AS
+    WITH uppsala AS (
+        SELECT municipality.geom FROM api.municipality WHERE municipality.code = '0380'
+    ), osm_objs AS (
+        SELECT id, type, tags, geom FROM osm.element
+        WHERE (element.tags->>'amenity' = 'bbq' OR element.tags->>'leisure' = 'firepit')
+                  AND ST_Within(geom, (SELECT uppsala.geom FROM uppsala)) AND type = 'n'
+    ), ups_objs AS (
+     SELECT ARRAY[item.id] AS id,
+        item.geometry,
+        tag_alternatives(
+                        ARRAY[jsonb_build_object('amenity', 'bbq'), jsonb_build_object('leisure', 'firepit')],
+                        jsonb_strip_nulls(jsonb_build_object(
+                                'wood_provided', CASE WHEN item.original_attributes->>'Kommentar'::text ~ 'Ved finns\.' THEN 'yes'
+                                                      WHEN item.original_attributes->>'Kommentar'::text ~ 'Ved finns inte\.' THEN 'no'
+                                                      ELSE NULL
+                                                 END
+                        ))
+                ) as tags,
+                item.original_attributes->>'Kommentar'::text as comment
+       FROM upstream.item
+      WHERE item.dataset_id = 466
+    )
+    SELECT DISTINCT ON (ups_objs.id)
+        ups_objs.id AS upstream_item_ids, ups_objs.tags AS upstream_tags, ups_objs.geometry AS upstream_geom,
+        osm_objs.id AS osm_element_id, osm_objs.type AS osm_element_type, osm_objs.tags AS osm_tags,
+                ups_objs.comment AS upstream_comment
+    FROM ups_objs
+    LEFT OUTER JOIN osm_objs ON match_condition(25, osm_objs.geom, ups_objs.geometry)
+    ORDER BY ups_objs.id, match_score(25, osm_objs.geom, ups_objs.geometry);
+
+DROP MATERIALIZED VIEW IF EXISTS upstream.mv_match_grillplatser_uppsala CASCADE;
+CREATE MATERIALIZED VIEW upstream.mv_match_grillplatser_uppsala AS SELECT * FROM upstream.v_match_grillplatser_uppsala;
+ALTER TABLE upstream.mv_match_grillplatser_uppsala OWNER TO app;
+
+CREATE OR REPLACE VIEW upstream.v_deviation_grillplatser_uppsala AS
+    SELECT *
+    FROM (SELECT DISTINCT ON (match_id)
+     466::bigint AS dataset_id,
+     18::bigint AS layer_id,
+     upstream_item_ids,
+     CASE
+         WHEN osm_element_id IS NULL THEN upstream_geom
+         ELSE NULL::geometry
+     END AS suggested_geom,
+     tag_diff(osm_tags, ups_tags) AS suggested_tags,
+     osm_element_id,
+     osm_element_type,
+     CASE
+         WHEN osm_element_id IS NULL THEN 'Grillplats saknas'::text
+         ELSE 'Grillplats saknar taggar'::text
+     END AS title,
+     CASE
+         WHEN osm_element_id IS NULL THEN 'Enligt Uppsala kommun ska det finnas en grillplats här'::text
+         ELSE 'Följande taggar, härledda ur från Uppsala kommuns data, saknas på grillplatsen här'::text
+     END AS description,
+     CASE WHEN upstream_comment IS NOT NULL THEN 'Kommentar från Uppsala kommun: ' || upstream_comment
+                  ELSE ''
+             END AS note
+           FROM (SELECT ROW_NUMBER() OVER () AS match_id, * FROM upstream.mv_match_grillplatser_uppsala) sub
+           LEFT JOIN LATERAL jsonb_array_elements(upstream_tags) ups_tags ON true
+           ORDER BY match_id, count_jsonb_keys(tag_diff(osm_tags, ups_tags)) ASC
+    ) sub
+    WHERE osm_element_id IS NULL OR suggested_tags <> '{}'::jsonb;
+
+CREATE OR REPLACE FUNCTION api.tile_match_grillplatser_uppsala(z integer, x integer, y integer)
+    RETURNS bytea
+    LANGUAGE 'sql'
+    STABLE PARALLEL SAFE
+    SECURITY DEFINER
+AS $$
+    WITH
+        bounds AS (SELECT ST_TileEnvelope(z, x, y) AS geom),
+        mvtgeom AS (
+            SELECT ST_AsMVTGeom(ST_Transform(CASE
+                                             WHEN items.upstream_geom IS NOT NULL AND element.geom IS NOT NULL THEN ST_MakeLine(ST_Centroid(items.upstream_geom), ST_Centroid(element.geom))
+                                             WHEN items.upstream_geom IS NOT NULL THEN ST_Centroid(items.upstream_geom)
+                                             WHEN element.geom IS NOT NULL THEN ST_Centroid(element.geom)
+                                             END, 3857), bounds.geom) AS geom,
+                items.upstream_tags::text AS upstream_tags,
+                CASE WHEN element.id IS NULL THEN 'not-in-osm'
+                     WHEN array_length(items.upstream_item_ids, 1) IS NULL THEN 'not-in-upstream'
+                     ELSE 'in-both' END AS state
+            FROM upstream.mv_match_grillplatser_uppsala items
+            LEFT OUTER JOIN osm.element ON items.osm_element_id = element.id AND items.osm_element_type = element.type
+            INNER JOIN bounds ON ST_Intersects(items.upstream_geom, ST_Transform(bounds.geom, 3006)) OR (element.id IS NOT NULL AND ST_Intersects(element.geom, ST_Transform(bounds.geom, 3006)))
+        )
+        SELECT ST_AsMVT(mvtgeom, 'default')
+        FROM mvtgeom;
+$$;


### PR DESCRIPTION
Matchar [amenity=bbq](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbbq) och [leisure=firepit](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dfirepit).

Föreslår [amenity=bbq](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbbq) + [wood_provided=yes/no](https://wiki.openstreetmap.org/wiki/Key:wood_provided) om det går att tolka från kommentarerna på objekten.

Kommentarerna innehåller även "Tillgänglighetsanpassad." och "Ej tillgänglighetsanpassad.". Ingen aning om hur man vettigt tolkar det i OSM-termer.

Sen krockar grillplatserna ganska friskt. Finns det någon bra strategi för att undvika det?
![image](https://github.com/02JanDal/osm-bjk/assets/1675190/b7a23d2a-6cbf-49e9-b31f-8ecde839dbd0)


Alla unika kommentarer:
<details><summary>Details</summary>
<p>

```
Fläktanstugan. Ved finns.
Grillplats inplanerad. Ved finns inte.
Kolarkojan. Ved finns inte.
Ved finns.
Ved finns. 
Ved finns. Ej tillgänglighetsanpassad
Ved finns. Ej tillgänglighetsanpassad.
Ved finns. Grillplats under tak.
Ved finns i gropen. 
Ved finns inte.
Ved finns inte. 
Ved finns inte. Ej tillgänglighetsanpassad.
Ved finns inte. Kung Skutes hög.
Ved finns inte. Tillgänglighetsanpassad.
Ved finns intill.
Ved finns intill cafeét.
Ved finns i vedförråd längs stigen.
Ved finns i vedförråd vid cafeét.
Ved finns norr om platsen.
Ved finns.  Tillgänglighetsanpassad.
Ved finns. Tillgänglighetsanpassad
Ved finns. Tillgänglighetsanpassad.
Ved finns vid grillplatsen ute på holmen.
Ved finns vid gropen.
Ved finns vid gropen. Tillgänglighetsanpassad.
Ved finns vid Östbergstorpet.
Ved finns vid servicebyggnaden.
Ved finns vid servicebyggnaden. Tillgänglighetsanpassad.
Ved finns vid vid servicebyggnaden.
Vedförråd.
Vindskyddet. Ved finns.
```

</p>
</details> 